### PR TITLE
fix: update the module export to the new naming scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "umd": "./dist/next-purge-css-modules.umd.js",
-      "import": "./dist/next-purge-css-modules.mjs",
+      "import": "./dist/next-purge-css-modules.module.js",
       "require": "./dist/next-purge-css-modules.cjs"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-purge-css-modules",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Easily remove unused css-module code in your Next.js application",
   "author": "Liam Howell <liam@liam.codes>",
   "homepage": "https://github.com/eels/next-purge-css-modules#readme",


### PR DESCRIPTION
This fixes-ish the package for next projects using `"type": "module"` 🤠

Will still need to switch out the `require` calls in `createLoader.ts` for it to actually work (which is as easy as replacing `require.resolve` with a string and importing `postcss`).

(hopefully I properly followed your commit style, let me know if not and I'll `git commit --amend` 😊)